### PR TITLE
fix: fix iframe size

### DIFF
--- a/packages/app/src/routes/index.page.tsx
+++ b/packages/app/src/routes/index.page.tsx
@@ -501,7 +501,7 @@ function VideoPlayer({
   return (
     <div className="flex flex-col gap-2">
       <div className="relative w-full aspect-video overflow-hidden">
-        <div ref={ref} className="absolute inset-0" />
+        <div ref={ref} className="absolute w-full h-full" />
         <Transition
           show={!player}
           className="absolute inset-0 flex justify-center items-center transition duration-300"


### PR DESCRIPTION
I thought `inset-0` and `w-full h-full` are equivalent but probably it had some tricky interaction with the parents `aspect-video`.

## before

<details>

![image](https://user-images.githubusercontent.com/4232207/236667161-47fc4824-61b3-42ad-b3a8-ee393161534e.png)

</details>

## before

<details>

![image](https://user-images.githubusercontent.com/4232207/236667145-4f6a3da2-f06e-41ff-8f4b-48011673c43a.png)

</details>