### PR TITLE
chore: enable vercel config `supportsResponseStreaming`

### DIFF
--- a/packages/app/misc/vercel/.vc-config.json
+++ b/packages/app/misc/vercel/.vc-config.json
@@ -2,5 +2,6 @@
   "runtime": "nodejs16.x",
   "handler": "index.js",
   "launcherType": "Nodejs",
+  "supportsResponseStreaming": true,
   "regions": ["hnd1"]
 }


### PR DESCRIPTION
It looks like vercel managed to implement the streaming on aws lambda by some cool hack.
Let's see if it works for our heavy `download.api.ts` endpoint.

## references

- https://vercel.com/docs/build-output-api/v3/primitives#base-config
- https://vercel.com/blog/streaming-for-serverless-node-js-and-edge-runtimes-with-vercel-functions

