### PR TITLE
refactor: replace File with Blob and remove polyfill

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,7 +62,6 @@
     "@miniflare/kv": "^2.14.0",
     "@miniflare/storage-file": "^2.14.0",
     "@playwright/test": "^1.31.2",
-    "@remix-run/web-file": "^3.0.2",
     "@types/lodash": "^4.14.186",
     "@types/node": "^18",
     "@types/react": "^18.0.20",

--- a/packages/app/src/misc/vitest/setup.ts
+++ b/packages/app/src/misc/vitest/setup.ts
@@ -1,10 +1,6 @@
 import { beforeAll } from "vitest";
 import { initializeServer } from "../../utils/server-utils";
 
-// @ts-expect-error prettier-ignore
-import { File, Blob } from "@remix-run/web-file";
-
 beforeAll(async () => {
-  Object.assign(globalThis, { File, Blob });
   await initializeServer();
 });

--- a/packages/app/src/utils/form-data-utils.test.ts
+++ b/packages/app/src/utils/form-data-utils.test.ts
@@ -6,31 +6,32 @@ it("basic", () => {
     metadata: { key: "value" },
     files: [new Blob(["abc"]), new Blob(["defghi"])],
   });
-  expect(formData).toMatchInlineSnapshot(`
-    FormData {
-      Symbol(state): [
-        {
-          "name": "metadata",
-          "value": "{\\"key\\":\\"value\\"}",
-        },
-        {
-          "name": "files",
-          "value": File {
-            Symbol(kHandle): Blob {},
-            Symbol(kLength): 3,
-            Symbol(kType): "",
-          },
-        },
-        {
-          "name": "files",
-          "value": File {
-            Symbol(kHandle): Blob {},
-            Symbol(kLength): 6,
-            Symbol(kType): "",
-          },
+
+  let entries: any[] = [];
+  formData.forEach((v, k) => entries.push([k, v]));
+  expect(entries).toMatchInlineSnapshot(`
+    [
+      [
+        "metadata",
+        "{\\"key\\":\\"value\\"}",
+      ],
+      [
+        "files",
+        File {
+          Symbol(kHandle): Blob {},
+          Symbol(kLength): 3,
+          Symbol(kType): "",
         },
       ],
-    }
+      [
+        "files",
+        File {
+          Symbol(kHandle): Blob {},
+          Symbol(kLength): 6,
+          Symbol(kType): "",
+        },
+      ],
+    ]
   `);
 
   const parsed = parseFormData(formData);

--- a/packages/app/src/utils/form-data-utils.test.ts
+++ b/packages/app/src/utils/form-data-utils.test.ts
@@ -4,10 +4,7 @@ import { createFormData, parseFormData } from "./form-data-utils";
 it("basic", () => {
   const formData = createFormData({
     metadata: { key: "value" },
-    files: [
-      new Blob(["abc"]),
-      new Blob(["defghi"]),
-    ],
+    files: [new Blob(["abc"]), new Blob(["defghi"])],
   });
   expect(formData).toMatchInlineSnapshot(`
     FormData {

--- a/packages/app/src/utils/form-data-utils.test.ts
+++ b/packages/app/src/utils/form-data-utils.test.ts
@@ -5,8 +5,8 @@ it("basic", () => {
   const formData = createFormData({
     metadata: { key: "value" },
     files: [
-      new File(["abc"], "test1.txt", { lastModified: 1 }),
-      new File(["defghi"], "test2.txt", { lastModified: 2 }),
+      new Blob(["abc"]),
+      new Blob(["defghi"]),
     ],
   });
   expect(formData).toMatchInlineSnapshot(`
@@ -19,8 +19,6 @@ it("basic", () => {
         {
           "name": "files",
           "value": File {
-            "_lastModified": 1,
-            "_name": "test1.txt",
             Symbol(kHandle): Blob {},
             Symbol(kLength): 3,
             Symbol(kType): "",
@@ -29,8 +27,6 @@ it("basic", () => {
         {
           "name": "files",
           "value": File {
-            "_lastModified": 2,
-            "_name": "test2.txt",
             Symbol(kHandle): Blob {},
             Symbol(kLength): 6,
             Symbol(kType): "",
@@ -45,15 +41,11 @@ it("basic", () => {
     {
       "files": [
         File {
-          "_lastModified": 1,
-          "_name": "test1.txt",
           Symbol(kHandle): Blob {},
           Symbol(kLength): 3,
           Symbol(kType): "",
         },
         File {
-          "_lastModified": 2,
-          "_name": "test2.txt",
           Symbol(kHandle): Blob {},
           Symbol(kLength): 6,
           Symbol(kType): "",

--- a/packages/app/src/utils/form-data-utils.ts
+++ b/packages/app/src/utils/form-data-utils.ts
@@ -10,7 +10,7 @@ export function createFormData({
   files,
 }: {
   metadata: unknown;
-  files: File[];
+  files: Blob[];
 }): FormData {
   const formData = new FormData();
   formData.set(KEY.metadata, JSON.stringify(metadata));
@@ -26,9 +26,9 @@ export function parseFormData(formData: FormData) {
   const metadata: unknown = JSON.parse(metadataRaw);
 
   const filesRaw = formData.getAll(KEY.files);
-  const files: File[] = [];
+  const files: Blob[] = [];
   for (const file of filesRaw) {
-    tinyassert(file instanceof File);
+    tinyassert(file instanceof Blob);
     files.push(file);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
       '@playwright/test':
         specifier: ^1.31.2
         version: 1.31.2
-      '@remix-run/web-file':
-        specifier: ^3.0.2
-        version: 3.0.2
       '@types/lodash':
         specifier: ^4.14.186
         version: 4.14.186
@@ -2426,25 +2423,6 @@ packages:
     resolution: {integrity: sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q==}
     engines: {node: '>=14'}
 
-  /@remix-run/web-blob@3.0.4:
-    resolution: {integrity: sha512-AfegzZvSSDc+LwnXV+SwROTrDtoLiPxeFW+jxgvtDAnkuCX1rrzmVJ6CzqZ1Ai0bVfmJadkG5GxtAfYclpPmgw==}
-    dependencies:
-      '@remix-run/web-stream': 1.0.3
-      web-encoding: 1.1.5
-    dev: true
-
-  /@remix-run/web-file@3.0.2:
-    resolution: {integrity: sha512-eFC93Onh/rZ5kUNpCQersmBtxedGpaXK2/gsUl49BYSGK/DvuPu3l06vmquEDdcPaEuXcsdGP0L7zrmUqrqo4A==}
-    dependencies:
-      '@remix-run/web-blob': 3.0.4
-    dev: true
-
-  /@remix-run/web-stream@1.0.3:
-    resolution: {integrity: sha512-wlezlJaA5NF6SsNMiwQnnAW6tnPzQ5I8qk0Y0pSohm0eHKa2FQ1QhEKLVVcDDu02TmkfHgnux0igNfeYhDOXiA==}
-    dependencies:
-      web-streams-polyfill: 3.2.1
-    dev: true
-
   /@rollup/pluginutils@5.0.2:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
@@ -2784,12 +2762,6 @@ packages:
       - supports-color
     dev: true
 
-  /@zxing/text-encoding@0.9.0:
-    resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
@@ -2839,11 +2811,6 @@ packages:
 
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-    dev: true
-
-  /available-typed-arrays@1.0.5:
-    resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
-    engines: {node: '>= 0.4'}
     dev: true
 
   /balanced-match@1.0.2:
@@ -3587,12 +3554,6 @@ packages:
       path-exists: 4.0.0
     dev: true
 
-  /for-each@0.3.3:
-    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
-    dependencies:
-      is-callable: 1.2.7
-    dev: true
-
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: true
@@ -3682,12 +3643,6 @@ packages:
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
-    dev: true
-
-  /gopd@1.0.1:
-    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
-    dependencies:
-      get-intrinsic: 1.1.3
     dev: true
 
   /graceful-fs@4.2.10:
@@ -3780,14 +3735,6 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
-  /is-arguments@1.1.1:
-    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      has-tostringtag: 1.0.0
-    dev: true
-
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
     dev: true
@@ -3834,13 +3781,6 @@ packages:
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /is-generator-function@1.0.10:
-    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: 1.0.0
     dev: true
 
   /is-glob@4.0.3:
@@ -3903,17 +3843,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
-    dev: true
-
-  /is-typed-array@1.1.10:
-    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-tostringtag: 1.0.0
     dev: true
 
   /is-weakref@1.0.2:
@@ -5082,16 +5011,6 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /util@0.12.5:
-    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
-    dependencies:
-      inherits: 2.0.4
-      is-arguments: 1.1.1
-      is-generator-function: 1.0.10
-      is-typed-array: 1.1.10
-      which-typed-array: 1.1.9
-    dev: true
-
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -5219,19 +5138,6 @@ packages:
       - terser
     dev: true
 
-  /web-encoding@1.1.5:
-    resolution: {integrity: sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==}
-    dependencies:
-      util: 0.12.5
-    optionalDependencies:
-      '@zxing/text-encoding': 0.9.0
-    dev: true
-
-  /web-streams-polyfill@3.2.1:
-    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
-    engines: {node: '>= 8'}
-    dev: true
-
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
     dependencies:
@@ -5240,18 +5146,6 @@ packages:
       is-number-object: 1.0.7
       is-string: 1.0.7
       is-symbol: 1.0.4
-    dev: true
-
-  /which-typed-array@1.1.9:
-    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-tostringtag: 1.0.0
-      is-typed-array: 1.1.10
     dev: true
 
   /which@1.3.1:


### PR DESCRIPTION
For some time, we're getting an odd error on CI

- https://github.com/hi-ogawa/youtube-dl-web-v2/actions/runs/6680036826/job/18152742245#step:9:23

```
packages/app test:  ❯ src/utils/form-data-utils.test.ts  (1 test | 1 failed) 26ms
packages/app test:    ❯ src/utils/form-data-utils.test.ts > basic
packages/app test:      → Snapshot `basic 1` mismatched
packages/app test: ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
packages/app test:  FAIL  src/utils/form-data-utils.test.ts > basic
packages/app test: AssertionError: Snapshot `basic 1` mismatched
packages/app test:  ❯ src/utils/form-data-utils.test.ts:12:19
packages/app test:      10|     ],
packages/app test:      11|   });
packages/app test:      12|   expect(formData).toMatchInlineSnapshot(`
packages/app test:        |                   ^
packages/app test:      13|     FormData {
packages/app test:      14|       Symbol(state): [
packages/app test:   - Expected  - 1
packages/app test:   + Received  + 1
packages/app test:   
packages/app test:   - FormData {
packages/app test:   + "_FormData {
```

Probably native and polyfill class is conflicting somehow.
I realized the polyfill is not necessarily since node 18 has Blob global, so trying to remove the polyfill here.